### PR TITLE
Allow dockerfile to build smaller image

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,7 @@ module.exports = withPWA({
   },
   distDir: process.env.BUILD_DIR || ".next",
   trailingSlash: true,
+  output: 'standalone',
   // async headers() {
   //   return [
   //     {


### PR DESCRIPTION
Hi, I had made changes to `next.config.js` to allow for docker to build smaller image, sadly I am not a dev, would you mind reviewing for whether I have place it at the right place?